### PR TITLE
Ignored extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ npm install live-ftp-upload
 require('live-ftp-upload')({
     dir : './path/to/watch',
     remoteDir : '/where/to/upload',
+    ignored: ["tmp", "bin"],
     connect : {
         host : 'remote-env.example.com',
         user : 'ftp-user',

--- a/index.js
+++ b/index.js
@@ -292,6 +292,8 @@ module.exports = function(opts, cb) {
             opts.persistent :
             true
     }, function(event, filename, pathname) {
+        var ignored = opts.ignored || [];
+        var extension;
         if (!filename) {
             // happens on adds and deletes - no filename provided
             return;
@@ -299,7 +301,13 @@ module.exports = function(opts, cb) {
 
         if (getAndSetFiredRecently(pathname)) return;
 
+        extension = pathname.split('.').pop();
         console.log(pathname + ' changed.');
+
+        if(ignored.indexOf(extension) !== -1) {
+            console.log(filename + " ignored.");
+            return;
+        }
 
         fs.stat(pathname, function(err, stat) {
             if (err) throw err;
@@ -317,6 +325,7 @@ module.exports.exampleOpts = {
     remoteDir : '/',
     filter : null,
     persistent : true,
+    ignored: ["tmp"],
     connect : {
         host : 'remote.com',
         port : '1337',


### PR DESCRIPTION
Add ability to set array of ignored extensions, like `['tmp', 'bin']`, which won't be uploaded.
